### PR TITLE
Hunt for most recently prepared prey first

### DIFF
--- a/lib/scorpion/hunting_map.rb
+++ b/lib/scorpion/hunting_map.rb
@@ -31,8 +31,8 @@ module Scorpion
 
     def initialize( scorpion )
       @scorpion = scorpion
-      @prey_set = @active_prey_set = Set.new
-      @shared_prey_set = Set.new
+      @prey_set = @active_prey_set = []
+      @shared_prey_set = []
     end
 
     # Find {Prey} that matches the requested `contract` and `traits`.
@@ -66,7 +66,7 @@ module Scorpion
     # @param [Array<Symbol>] traits found on the {Prey}.
     # @return [Scorpion::Prey] the prey to be hunted for.
     def hunt_for( contract, traits = nil, &builder )
-      active_prey_set << prey_class( contract, &builder ).new( contract, traits, &builder )
+      active_prey_set.unshift prey_class( contract, &builder ).new( contract, traits, &builder )
     end
     alias_method :offer, :hunt_for
 
@@ -74,7 +74,7 @@ module Scorpion
     # for the resource.
     # @see #hunt_for
     def capture( contract, traits = nil, &builder )
-      active_prey_set << Scorpion::Prey::CapturedPrey.new( prey_class( contract, &builder ).new( contract, traits, &builder ) )
+      active_prey_set.unshift Scorpion::Prey::CapturedPrey.new( prey_class( contract, &builder ).new( contract, traits, &builder ) )
     end
     alias_method :singleton, :capture
 

--- a/lib/scorpion/version.rb
+++ b/lib/scorpion/version.rb
@@ -1,5 +1,5 @@
 module Scorpion
-  VERSION_NUMBER  = "0.2.0"
+  VERSION_NUMBER  = "0.3.0"
   VERSION_SUFFIX  = ""
   VERSION         = "#{VERSION_NUMBER}#{VERSION_SUFFIX}"
 end

--- a/spec/lib/scorpion/hunter_spec.rb
+++ b/spec/lib/scorpion/hunter_spec.rb
@@ -28,23 +28,24 @@ describe Scorpion::Hunter do
 
   let( :hunter ) do
     Scorpion::Hunter.new do
+      capture Test::Hunter::Lion, :tame
+
       hunt_for Test::Hunter::Bear
       hunt_for Test::Hunter::Lion, :male
       hunt_for Test::Hunter::Grizly, :female
       hunt_for Test::Hunter::Argumented
 
-      capture Test::Hunter::Lion, :tame
       hunt_for Test::Hunter::Zoo
     end
   end
 
   it "spawns prey" do
-    expect( hunter.hunt Test::Hunter::Beast ).to be_a Test::Hunter::Bear
+    expect( hunter.hunt Test::Hunter::Beast ).to be_a Test::Hunter::Beast
   end
 
   it "spawns a new instance for multiple requests" do
     first = hunter.hunt Test::Hunter::Beast
-    expect( hunter.hunt Test::Hunter::Beast ).not_to eq first
+    expect( hunter.hunt Test::Hunter::Beast ).not_to be first
   end
 
   it "spawns the same instance for captured prey" do

--- a/spec/lib/scorpion/hunting_map_spec.rb
+++ b/spec/lib/scorpion/hunting_map_spec.rb
@@ -54,15 +54,15 @@ describe Scorpion::HuntingMap do
         end
       end
 
-      it "returns the first prey that matches one trait" do
-        expect( map.find( Test::HuntingMap::Weapon, :one_handed ).traits ).to include :sharp
+      it "returns the last prey that matches one trait" do
+        expect( map.find( Test::HuntingMap::Weapon, :one_handed ).traits ).to include :blunt
       end
 
-      it "returns the first prey that matches all of the traits" do
+      it "returns the last prey that matches all of the traits" do
         expect( map.find( Test::HuntingMap::Weapon, [ :one_handed, :blunt ] ).traits ).to include :blunt
       end
 
-      it "returns the first prey that matches a unique trait" do
+      it "returns the last prey that matches a unique trait" do
         expect( map.find( Test::HuntingMap::Weapon, :blunt ).traits ).to include :blunt
       end
     end


### PR DESCRIPTION
When preparing scorpion hunters, prey that is declared later, should override prey declared earlier so that derived and child hunters can override.