### PR TITLE
Support hunting delegates

### DIFF
--- a/lib/scorpion/prey/builder_prey.rb
+++ b/lib/scorpion/prey/builder_prey.rb
@@ -2,7 +2,8 @@ require 'scorpion/prey'
 
 module Scorpion
   class Prey
-    # {Prey} for an explicit builder block
+    # {Prey} that delegates to another object that implements
+    # #call( scorpion, *args, &block ).
     class BuilderPrey < Scorpion::Prey
 
       # ============================================================================
@@ -10,16 +11,15 @@ module Scorpion
       #
 
       # @!attribute
-      # @return [#call(scorpion)] the builder to use to fetch instances of the prey.
+      # @return [#call(scorpion,*args,&block)] the builder to use to fetch instances of the prey.
         attr_reader :builder
 
       #
       # @!endgroup Attributes
 
-
-      def initialize( contract, traits = nil, &builder )
-        @builder = builder
-        super
+      def initialize( contract, traits = nil, builder = nil, &block )
+        @builder = block_given? ? block : builder
+        super contract, traits
       end
 
       # @see Scorpion::Prey#fetch

--- a/lib/scorpion/version.rb
+++ b/lib/scorpion/version.rb
@@ -1,5 +1,5 @@
 module Scorpion
-  VERSION_NUMBER  = "0.3.0"
+  VERSION_NUMBER  = "0.3.1"
   VERSION_SUFFIX  = ""
   VERSION         = "#{VERSION_NUMBER}#{VERSION_SUFFIX}"
 end

--- a/spec/lib/scorpion/hunting_map_spec.rb
+++ b/spec/lib/scorpion/hunting_map_spec.rb
@@ -88,6 +88,14 @@ describe Scorpion::HuntingMap do
 
       expect( map.first ).to be_a Scorpion::Prey::BuilderPrey
     end
+
+    it "adds a BuilderPrey for with: option" do
+      map.chart do
+        hunt_for String, with: ->(scorpion,*args,&block){ "YASSS" }
+      end
+
+      expect( map.first ).to be_a Scorpion::Prey::BuilderPrey
+    end
   end
 
   describe "#replicate_from" do

--- a/spec/lib/scorpion/prey/builder_prey_spec.rb
+++ b/spec/lib/scorpion/prey/builder_prey_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Test
+  module BuilderPrey
+    class ClassDelegate
+      def call( scorpion, *args, &block )
+        Test
+      end
+    end
+
+    module ModDelegate
+      module_function
+
+      def call( scorpion, *args, &block )
+        Test
+      end
+    end
+  end
+end
+
+describe Scorpion::Prey::BuilderPrey do
+  let( :scorpion ){ double }
+
+  it "supports class hunting delegates" do
+    prey = Scorpion::Prey::BuilderPrey.new( String, nil, Test::BuilderPrey::ClassDelegate.new )
+    expect( prey.fetch( scorpion ) ).to be Test
+  end
+
+  it "supports module hunting delegates" do
+    prey = Scorpion::Prey::BuilderPrey.new( String, nil, Test::BuilderPrey::ModDelegate )
+    expect( prey.fetch( scorpion ) ).to be Test
+  end
+
+  it "supports block hunting delegates" do
+    prey = Scorpion::Prey::BuilderPrey.new( String, nil ) do
+      Test
+    end
+    expect( prey.fetch( scorpion ) ).to be Test
+  end
+
+
+end


### PR DESCRIPTION
Hunting delegates allow complex dependency resolution to be managed by a custom class or factory.