### PR TITLE
Heavy unused Trip@caller varible removed

### DIFF
--- a/lib/scorpion/hunt.rb
+++ b/lib/scorpion/hunt.rb
@@ -159,8 +159,6 @@ module Scorpion
           @arguments    = arguments
           @dependencies = dependencies
           @block        = block
-
-          @caller = caller
         end
       end
 


### PR DESCRIPTION
`@caller` doesn't seem to be used anywhere in the code while `Kernel#caller` seem to be a pretty heavy method. Here is some performance report:

**Test script**
```
require 'ruby-prof'

class Hunter < Object; end

scorpion = Scorpion.instance

RubyProf.start
10_000.times {
  scorpion.fetch Hunter
}
result = RubyProf.stop

printer = RubyProf::FlatPrinter.new(result)
printer.print(STDOUT)
```

**Output:**
```
Measure Mode: wall_time
Thread ID: 70246518225420
Fiber ID: 70246558554500
Total: 1.253425
Sort by: self_time

 %self      total      self      wait     child     calls  name
 28.88      0.362     0.362     0.000     0.000    10000   Kernel#caller
 11.38      0.399     0.143     0.000     0.257    30000   Array#each
  7.35      0.150     0.092     0.000     0.057   140000   Scorpion::Dependency#satisfies_contract?
  4.42      0.198     0.055     0.000     0.143   100000   Scorpion::Dependency::CapturedDependency#satisfies?
  4.13      0.201     0.052     0.000     0.150   140000   Scorpion::Dependency#satisfies?
  3.49      0.114     0.044     0.000     0.070    10000   Scorpion::Dependency::ClassDependency#fetch
  3.04      0.421     0.038     0.000     0.383    10000   Scorpion::Hunt#initialize
  2.95      0.735     0.037     0.000     0.698    10000   Scorpion::Hunter#execute
  2.71      0.545     0.034     0.000     0.511    60000  *Class#new
  2.45      1.245     0.031     0.000     1.214    10000   Scorpion#fetch
```