### PR TITLE
Remove 'traits' selection for scorpion fetching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scorpion-ioc (0.6.2)
+    scorpion-ioc (1.0.0)
       rails (>= 4.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -10,29 +10,30 @@ Add IoC to rails with minimal fuss and ceremony.
 
 (Also check out [shog](http://github.com/phallguy/shog) for better rails logs)
 
-<!-- MarkdownTOC depth=4 -->
+<!-- vim-markdown-toc GFM -->
 
-- [Dependency Injection](#dependency-injection)
-  - [Why might you _Want_ a DI FRamework?](#why-might-you-_want_-a-di-framework)
-    - [Using a Framework...like Scorpion](#using-a-frameworklike-scorpion)
-- [Using Scorpion](#using-scorpion)
-  - [Objects](#objects)
-  - [Configuration](#configuration)
-    - [Classes](#classes)
-    - [Modules](#modules)
-    - [Traits](#traits)
-    - [Builders](#builders)
-    - [Hunting Delegates](#hunting-delegates)
-    - [Singletons](#singletons)
-  - [Nests](#nests)
-  - [Rails](#rails)
-    - [ActionController](#actioncontroller)
-    - [ActiveJob](#activejob)
-    - [ActiveRecord](#activerecord)
-- [Contributing](#contributing)
-- [License](#license)
+* [Dependency Injection](#dependency-injection)
+  * [Why might you _Want_ a DI FRamework?](#why-might-you-_want_-a-di-framework)
+      * [Setter/Default Injection](#setterdefault-injection)
+      * [Constructor/Ignorant Injection](#constructorignorant-injection)
+    * [Using a Framework...like Scorpion](#using-a-frameworklike-scorpion)
+* [Using Scorpion](#using-scorpion)
+  * [Objects](#objects)
+  * [Configuration](#configuration)
+    * [Classes](#classes)
+    * [Modules](#modules)
+    * [Builders](#builders)
+    * [Hunting Delegates](#hunting-delegates)
+    * [Singletons](#singletons)
+  * [Nests](#nests)
+  * [Rails](#rails)
+    * [ActionController](#actioncontroller)
+    * [ActiveJob](#activejob)
+    * [ActiveRecord](#activerecord)
+* [Contributing](#contributing)
+* [License](#license)
 
-<!-- /MarkdownTOC -->
+<!-- vim-markdown-toc -->
 
 ## Dependency Injection
 
@@ -288,52 +289,6 @@ end
 
 poker = scorpion.fetch Sharp
 poker.poke     # => "Sword"
-```
-
-#### Traits
-
-Traits can be used to distinguish between dependencies of the same type. For
-example a scorpion may be prepared to hunt for several weapons and the object
-needs a blunt weapon.
-
-```ruby
-class Weapon; end
-class Mace < Weapon; end
-class Hammer < Weapon; end
-class Sword < Weapon; end
-
-scorpion.prepare do
-  hunt_for Hammer, :blunt
-  hunt_for Sword, :sharp
-  hunt_for Mace, :blunt, :sharp
-end
-
-scorpion.fetch Weapon, :blunt # => Hammer.new
-scorpion.fetch Weapon, :sharp # => Sword.new
-scorpion.fetch Weapon, :sharp, :blunt # => Mace.new
-```
-
-Modules can also be used to identify specific traits desired from the hunted
-dependency.
-
-```ruby
-module Color; end
-module Streaming; end
-class Logger; end
-class Console < Logger
-  include Color
-end
-class SysLog < Logger
-  include Streaming
-end
-
-scorpion.prepare do
-  hunt_for Console
-  hunt_for SysLog
-end
-
-scorpion.fetch Logger, Color      # => Console.new
-scorpion.fetch Logger, Streaming  # => SysLog.new
 ```
 
 #### Builders

--- a/app/README
+++ b/app/README
@@ -1,0 +1,1 @@
+Here to make vim-rails work

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,0 +1,1 @@
+# Dummy file to make vim-rails work

--- a/lib/scorpion.rb
+++ b/lib/scorpion.rb
@@ -19,22 +19,15 @@ module Scorpion
   require "scorpion/stinger"
   require "scorpion/rails"
 
-  # Hunts for an object that satisfies the requested `contract` and `traits`.
+  # Hunts for an object that satisfies the requested `contract`.
+  #
   # @param [Class,Module,Symbol] contract describing the desired behavior of the dependency.
-  # @param [Array<Symbol>] traits required of the dependency
   # @param [Hash<Symbol,Object>] dependencies to inject into the object.
-  # @return [Object] an object that satisfies the contract and traits.
+  # @return [Object] an object that satisfies the contract.
   # @raise [UnsuccessfulHunt] if a matching object cannot be found.
-  def fetch_by_traits( contract, traits, *arguments, **dependencies, &block )
-    hunt = Hunt.new( self, contract, traits, *arguments, **dependencies, &block )
-    execute hunt
-  end
-
-  # Hunts for an object that satisfies the requested `contract` regardless of
-  # traits.
-  # @see #fetch_by_traits
   def fetch( contract, *arguments, **dependencies, &block )
-    fetch_by_traits( contract, nil, *arguments, **dependencies, &block )
+    hunt = Hunt.new( self, contract, *arguments, **dependencies, &block )
+    execute hunt
   end
 
   # Creates a new object and feeds it it's dependencies.
@@ -65,13 +58,13 @@ module Scorpion
   # @param [#call] block to pass to the constructor.
   # @return [Scorpion::Object] the spawned object.
   def new( object_class, *arguments, **dependencies, &block )
-    hunt = Hunt.new( self, object_class, nil, *arguments, **dependencies, &block )
+    hunt = Hunt.new( self, object_class, *arguments, **dependencies, &block )
     Scorpion::Dependency::ClassDependency.new( object_class ).fetch( hunt )
   end
 
   # Execute the `hunt` returning the desired dependency.
   # @param [Hunt] hunt to execute.
-  # @return [Object] an object that satisfies the hunt contract and traits.
+  # @return [Object] an object that satisfies the hunt contract.
   def execute( hunt )
     fail "Not implemented"
   end
@@ -146,12 +139,6 @@ module Scorpion
     instance.fetch dependencies, &block
   end
 
-  # Hunt for dependency from the primary Scorpion {#instance}.
-  # @see #fetch_by_traits
-  def self.fetch_by_traits( dependencies, &block )
-    instance.fetch_by_traits dependencies, &block
-  end
-
   # @!attribute logger
   # @return [Logger] logger for the Scorpion framework to use.
   def self.logger
@@ -170,8 +157,8 @@ module Scorpion
 
     # Used by concrete scorpions to notify the caller that the hunt was
     # unsuccessful.
-    def unsuccessful_hunt( contract, traits )
-      fail UnsuccessfulHunt.new contract, traits
+    def unsuccessful_hunt( contract )
+      fail UnsuccessfulHunt, contract
     end
 
 end

--- a/lib/scorpion/attribute.rb
+++ b/lib/scorpion/attribute.rb
@@ -19,10 +19,6 @@ module Scorpion
       end
 
     # @!attribute
-    # @return [Array<Symbol>] traits that must match on instances of the {#contract}
-      attr_reader :traits
-
-    # @!attribute
     # @return [Boolean] true if the attribute is not immediately required and
     #   will be hunted down on first use.
       def lazy?
@@ -45,36 +41,13 @@ module Scorpion
     # @!endgroup Attributes
 
 
-    def initialize( name, contract, traits = nil, lazy: false, public: false, private: false )
+    def initialize( name, contract, lazy: false, public: false, private: false )
       @name      = name.to_sym
       @contract  = contract
-      @traits    = Array( traits ).flatten.freeze
-      @trait_set = Set.new( @traits.map { |t| :"#{t}?" } )
       @lazy      = lazy
       @public    = public
       @private   = private
     end
 
-    def respond_to?( name, include_all = false )
-      super || trait_set.include?( name )
-    end
-
-    private
-
-      # @return [Set] the set of traits associated with the attribute pre-processed
-      #   to include the trait names with a '?' suffix.
-        attr_reader :trait_set
-
-      def method_missing( name, *args ) # rubocop:disable Style/MethodMissing
-        if trait_method?( name )
-          trait_set.include? name
-        else
-          super
-        end
-      end
-
-      def trait_method?( name )
-        name[-1] == "?"
-      end
   end
 end

--- a/lib/scorpion/attribute_set.rb
+++ b/lib/scorpion/attribute_set.rb
@@ -36,9 +36,8 @@ module Scorpion
     end
 
     # Defines the food that {Scorpion::Object} will feed on. A food is defined by
-    # invoking a method with the desired name passing the contract and traits
-    # desired. AttributeSet uses method_missing to dynamically define
-    # attributes.
+    # invoking a method with the desired name passing the contract desired.
+    # AttributeSet uses method_missing to dynamically define attributes.
     #
     # If the block takes an argument, AttributeSet will yield to the block
     # passing itself. If no argument is provided, yield will use the
@@ -71,16 +70,13 @@ module Scorpion
     end
 
     # Define a single attribute with the given name that expects food that will
-    # satisfy the contract and traits.
+    # satisfy the contract.
     # @param [String] name of the attribute.
     # @param [Class,Module,Symbol] contract that describes the desired behavior
     #   of the injected object.
-    # @param [Array<Symbol>] traits that must match on instances of the {#contract}
     # @return [Attribute] the attribute that was created.
-    def define_attribute( name, contract, *traits )
-      options = traits.pop if traits.last.is_a? Hash
-      options ||= {}
-      attributes[name.to_sym] = Attribute.new name, contract, traits, options
+    def define_attribute( name, contract, **options )
+      attributes[name.to_sym] = Attribute.new name, contract, options
     end
 
 

--- a/lib/scorpion/chain_hunter.rb
+++ b/lib/scorpion/chain_hunter.rb
@@ -51,7 +51,7 @@ module Scorpion
         end
       end
 
-      unsuccessful_hunt hunt.contract, hunt.traits
+      unsuccessful_hunt hunt.contract
     end
 
   end

--- a/lib/scorpion/dependency/argument_dependency.rb
+++ b/lib/scorpion/dependency/argument_dependency.rb
@@ -16,8 +16,8 @@ module Scorpion
         argument
       end
 
-      def satisfies?( contract, traits = nil )
-        contract === argument && traits.blank?
+      def satisfies?( contract )
+        contract === argument
       end
 
     end

--- a/lib/scorpion/dependency/builder_dependency.rb
+++ b/lib/scorpion/dependency/builder_dependency.rb
@@ -17,9 +17,9 @@ module Scorpion
       #
       # @!endgroup Attributes
 
-      def initialize( contract, traits = nil, builder = nil, &block )
+      def initialize( contract, builder = nil, &block )
         @builder = block_given? ? block : builder
-        super contract, traits
+        super contract
       end
 
       # @see Scorpion::Dependency#fetch

--- a/lib/scorpion/dependency/captured_dependency.rb
+++ b/lib/scorpion/dependency/captured_dependency.rb
@@ -20,7 +20,7 @@ module Scorpion
         private :specific_dependency
 
 
-      delegate [:contract, :traits, :satisfies?] => :specific_dependency
+      delegate [ :contract, :satisfies? ] => :specific_dependency
 
       #
       # @!endgroup Attributes

--- a/lib/scorpion/dependency/class_dependency.rb
+++ b/lib/scorpion/dependency/class_dependency.rb
@@ -19,7 +19,7 @@ module Scorpion
           hunt.contract.initializer_injections.each_with_object(dependencies.dup) do |attr, deps|
             next if attr.lazy?
 
-            deps[attr.name] ||= hunt.fetch_by_traits( attr.contract, attr.traits )
+            deps[attr.name] ||= hunt.fetch( attr.contract )
           end
         end
 

--- a/lib/scorpion/dependency_map.rb
+++ b/lib/scorpion/dependency_map.rb
@@ -33,13 +33,12 @@ module Scorpion
       reset
     end
 
-    # Find {Dependency} that matches the requested `contract` and `traits`.
+    # Find {Dependency} that matches the requested `contract`.
     # @param [Class,Module,Symbol] contract describing the desired behavior of the dependency.
-    # @param [Array<Symbol>] traits found on the {Dependency}.
     # @return [Dependency] the dependency matching the attribute.
-    def find( contract, traits = nil )
-      dependency_set.find { |p| p.satisfies?( contract, traits ) } ||
-        shared_dependency_set.find { |p| p.satisfies?( contract, traits ) }
+    def find( contract )
+      dependency_set.find { |p| p.satisfies?( contract ) } ||
+        shared_dependency_set.find { |p| p.satisfies?( contract ) }
     end
 
     # Chart the {Dependency} that this hunting map can {#find}.
@@ -75,24 +74,23 @@ module Scorpion
       self
     end
 
-    # Define {Dependency} that can be found on this map by `contract` and `traits`.
+    # Define {Dependency} that can be found on this map by `contract`.
     #
     # If a block is given, it will be used build the actual instances of the
     # dependency for the {Scorpion}.
     #
     # @param [Class,Module,Symbol] contract describing the desired behavior of the dependency.
-    # @param [Array<Symbol>] traits found on the {Dependency}.
     # @return [Dependency] the dependency to be hunted for.
-    def hunt_for( contract, traits = nil, &builder )
-      active_dependency_set.unshift define_dependency( contract, traits, &builder )
+    def hunt_for( contract, **options, &builder )
+      active_dependency_set.unshift define_dependency( contract, options, &builder )
     end
 
     # Captures a single dependency and returns the same instance fore each request
     # for the resource.
     # @see #hunt_for
     # @return [Dependency] the dependency to be hunted for.
-    def capture( contract, traits = nil, &builder )
-      active_dependency_set.unshift Dependency::CapturedDependency.new( define_dependency( contract, traits, &builder ) ) # rubocop:disable Metrics/LineLength
+    def capture( contract, **options, &builder )
+      active_dependency_set.unshift Dependency::CapturedDependency.new( define_dependency( contract, options, &builder ) )
     end
     alias_method :singleton, :capture
 
@@ -136,8 +134,8 @@ module Scorpion
 
     private
 
-      def define_dependency( contract, traits, &builder )
-        Dependency.define contract, traits, &builder
+      def define_dependency( contract, options, &builder )
+        Dependency.define contract, options, &builder
       end
   end
 end

--- a/lib/scorpion/error.rb
+++ b/lib/scorpion/error.rb
@@ -13,13 +13,11 @@ module Scorpion
 
   class UnsuccessfulHunt < Error
     attr_reader :contract
-    attr_reader :traits
 
-    def initialize( contract, traits = nil )
+    def initialize( contract )
       @contract = contract
-      @traits   = traits
 
-      super translate( :unsuccessful_hunt, contract: contract, traits: traits )
+      super translate( :unsuccessful_hunt, contract: contract )
     end
   end
 

--- a/lib/scorpion/hunter.rb
+++ b/lib/scorpion/hunter.rb
@@ -51,9 +51,9 @@ module Scorpion
     # @see Scorpion#execute
     def execute( hunt, explicit_only = false )
       dependency   = find_dependency( hunt )
-      dependency ||= Dependency.define( hunt.contract ) if hunt.traits.blank? && !explicit_only
+      dependency ||= Dependency.define( hunt.contract ) unless explicit_only
 
-      unsuccessful_hunt( hunt.contract, hunt.traits ) unless dependency
+      unsuccessful_hunt( hunt.contract ) unless dependency
 
       dependency.fetch hunt
     end
@@ -62,7 +62,7 @@ module Scorpion
     # @param [Hunt] hunt being resolved.
     # @return [Dependency] the matching dependency if found
     def find_dependency( hunt )
-      dependency   = dependency_map.find( hunt.contract, hunt.traits )
+      dependency   = dependency_map.find( hunt.contract )
       dependency ||= parent.find_dependency( hunt ) if parent
 
       dependency

--- a/lib/scorpion/locale/en.yml
+++ b/lib/scorpion/locale/en.yml
@@ -2,7 +2,7 @@ en:
   scorpion:
     errors:
       messages:
-        unsuccessful_hunt: "Couldn't find a %{contract} builder with traits '%{traits}'"
+        unsuccessful_hunt: "Couldn't find a %{contract} builder"
         builder_required: A custom builder must be provided to resolve this dependency
         arity_mismatch: The block must accept %{expected} arguments, but actually expects %{actual}
         rack_missing_scorpion: Scorpion not set. Add Scorpion::Rack::Middleware before %{middleware}.

--- a/lib/scorpion/object.rb
+++ b/lib/scorpion/object.rb
@@ -137,9 +137,8 @@ module Scorpion
       # Define a single dependency and accessor.
       # @param [Symbol] name of the dependency.
       # @param [Class,Module,Symbol] contract describing the desired behavior of the dependency.
-      # @param [Array<Symbol>] traits found on the {Dependency}.
-      def attr_dependency( name, contract, *traits, &block )
-        attr = injected_attributes.define_attribute name, contract, *traits, &block
+      def attr_dependency( name, contract, &block )
+        attr = injected_attributes.define_attribute name, contract, &block
         build_injected_attribute attr
         adjust_injected_attribute_visibility attr
         validate_initializer_injections
@@ -191,7 +190,7 @@ module Scorpion
             def #{ attr.name }
               @#{ attr.name } ||= begin
                 attr = injected_attributes[ :#{ attr.name } ]
-                scorpion.fetch_by_traits( attr.contract, attr.traits )
+                scorpion.fetch( attr.contract )
               end
             end
 

--- a/lib/scorpion/version.rb
+++ b/lib/scorpion/version.rb
@@ -1,5 +1,5 @@
 module Scorpion
-  VERSION_NUMBER  = "0.6.2".freeze
+  VERSION_NUMBER  = "1.0.0".freeze
   VERSION_SUFFIX  = "".freeze
   VERSION         = "#{ VERSION_NUMBER }#{ VERSION_SUFFIX }".freeze
 end

--- a/spec/lib/scorpion/attribute_set_spec.rb
+++ b/spec/lib/scorpion/attribute_set_spec.rb
@@ -42,24 +42,6 @@ describe Scorpion::AttributeSet do
       expect( set[:logger] ).to be_lazy
     end
 
-    it "parses traits" do
-      set.define do
-        with_traits nil, :color
-      end
-
-      expect( set[:with_traits].traits ).to eq [:color]
-    end
-
-    it "parses traits and options" do
-      set.define do
-        both nil, :formatted, lazy: true
-      end
-
-      expect( set[:both] ).to be_formatted
-      expect( set[:both] ).to be_lazy
-    end
-
-
     it "parses options" do
       set.define do
         options nil, lazy: true

--- a/spec/lib/scorpion/attribute_spec.rb
+++ b/spec/lib/scorpion/attribute_spec.rb
@@ -6,11 +6,6 @@ end
 
 
 describe Scorpion::Attribute do
-  it "responds to trait? methods" do
-    attr = Scorpion::Attribute.new :name, :contract, :formatted
-    expect( attr ).to be_formatted
-  end
-
   it "resolves contract strings to constants" do
     attr = Scorpion::Attribute.new :name, "Test::Attr"
     expect( attr.contract ).to be Test::Attr

--- a/spec/lib/scorpion/dependency/argument_dependency_spec.rb
+++ b/spec/lib/scorpion/dependency/argument_dependency_spec.rb
@@ -11,8 +11,4 @@ describe Scorpion::Dependency::ArgumentDependency do
   it "doesn't match different types" do
     expect( dependency.satisfies?( Regexp ) ).to be_falsy
   end
-
-  it "doesn't match traits" do
-    expect( dependency.satisfies?( String, :password ) ).to be_falsy
-  end
 end

--- a/spec/lib/scorpion/dependency/builder_dependency_spec.rb
+++ b/spec/lib/scorpion/dependency/builder_dependency_spec.rb
@@ -23,17 +23,17 @@ describe Scorpion::Dependency::BuilderDependency do
   let( :hunt ) { Scorpion::Hunt.new( scorpion, String, nil ) }
 
   it "supports class hunting delegates" do
-    dependency = Scorpion::Dependency::BuilderDependency.new( String, nil, Test::BuilderDependency::ClassDelegate.new )
+    dependency = Scorpion::Dependency::BuilderDependency.new( String, Test::BuilderDependency::ClassDelegate.new )
     expect( dependency.fetch( hunt ) ).to be Test
   end
 
   it "supports module hunting delegates" do
-    dependency = Scorpion::Dependency::BuilderDependency.new( String, nil, Test::BuilderDependency::ModDelegate )
+    dependency = Scorpion::Dependency::BuilderDependency.new( String, Test::BuilderDependency::ModDelegate )
     expect( dependency.fetch( hunt ) ).to be Test
   end
 
   it "supports block hunting delegates" do
-    dependency = Scorpion::Dependency::BuilderDependency.new( String, nil ) do
+    dependency = Scorpion::Dependency::BuilderDependency.new( String ) do
       Test
     end
     expect( dependency.fetch( hunt ) ).to be Test

--- a/spec/lib/scorpion/dependency_map_spec.rb
+++ b/spec/lib/scorpion/dependency_map_spec.rb
@@ -45,27 +45,6 @@ describe Scorpion::DependencyMap do
       expect( map.find( Test::DependencyMap::Armor ) ).to be_nil
     end
 
-
-    context "multiple possible matches" do
-      before( :each ) do
-        map.chart do
-          hunt_for Test::DependencyMap::Weapon, [ :sharp, :one_handed ]
-          hunt_for Test::DependencyMap::Weapon, [ :blunt, :one_handed ]
-        end
-      end
-
-      it "returns the last dependency that matches one trait" do
-        expect( map.find( Test::DependencyMap::Weapon, :one_handed ).traits ).to include :blunt
-      end
-
-      it "returns the last dependency that matches all of the traits" do
-        expect( map.find( Test::DependencyMap::Weapon, [ :one_handed, :blunt ] ).traits ).to include :blunt
-      end
-
-      it "returns the last dependency that matches a unique trait" do
-        expect( map.find( Test::DependencyMap::Weapon, :blunt ).traits ).to include :blunt
-      end
-    end
   end
 
   describe "#hunt_for" do

--- a/spec/lib/scorpion/dependency_spec.rb
+++ b/spec/lib/scorpion/dependency_spec.rb
@@ -39,35 +39,8 @@ describe Scorpion::Dependency do
 
   end
 
-  describe "traits" do
-
-    context "symbolic" do
-      let( :dependency ) { Scorpion::Dependency.new Test::Dependency::Base, :apples }
-      it "satisfies matched traits" do
-        expect( dependency.satisfies?(Test::Dependency::Base, :apples) ).to be_truthy
-      end
-
-      it "doesn't satisfy mis-matched traits" do
-        expect( dependency.satisfies?(Test::Dependency::Base, :oranges) ).to be_falsy
-      end
-    end
-
-    context "module" do
-      let( :dependency ) { Scorpion::Dependency.new Test::Dependency::Derived }
-
-      it "satisfies module traits" do
-        expect( dependency.satisfies?(Test::Dependency::Base, Test::Dependency::Derived) ).to be_truthy
-      end
-    end
-
-  end
-
   it "can satisfy symbol contracts" do
     expect( Scorpion::Dependency.new( :symbol ).satisfies?(:symbol) ).to be_truthy
-  end
-
-  it "satisfies ignores tail hash traits" do
-    expect( Scorpion::Dependency.new( Test::Dependency::Base ).satisfies?( Test::Dependency::Base ) )
   end
 
   describe "equality" do

--- a/spec/lib/scorpion/hunt_spec.rb
+++ b/spec/lib/scorpion/hunt_spec.rb
@@ -22,19 +22,19 @@ describe Scorpion::Hunt do
   let( :scorpion ) { double Scorpion }
   let( :hunt ) { Scorpion::Hunt.new scorpion, String, nil }
 
-  describe "#fetch_by_traits" do
+  describe "#fetch" do
     it "changes context" do
       expect( scorpion ).to receive( :execute ) do |hunt|
         expect( hunt.contract ).to eq Regexp
       end
 
-      hunt.fetch_by_traits Regexp, nil
+      hunt.fetch Regexp, nil
     end
 
     it "restores context" do
       expect( scorpion ).to receive( :execute )
 
-      hunt.fetch_by_traits Numeric, nil
+      hunt.fetch Numeric, nil
       expect( hunt.contract ).to eq String
     end
 
@@ -46,7 +46,7 @@ describe Scorpion::Hunt do
 
     it "finds matching argument in grandparent" do
       hunt = Scorpion::Hunt.new scorpion, String, nil, label: "Hello"
-      hunt.send :push, Regexp, nil, [], {}, nil
+      hunt.send :push, Regexp, [], {}, nil
 
       expect( scorpion ).to receive( :execute ) do |_|
         next if hunt.contract == String

--- a/spec/lib/scorpion/hunter_spec.rb
+++ b/spec/lib/scorpion/hunter_spec.rb
@@ -54,11 +54,10 @@ describe Scorpion::Hunter do
 
   let( :hunter ) do
     Scorpion::Hunter.new do
-      capture Test::Hunter::Lion, :tame
+      capture Test::Hunter::Lion
 
       hunt_for Test::Hunter::Bear
-      hunt_for Test::Hunter::Lion, :male
-      hunt_for Test::Hunter::Grizly, :female
+      hunt_for Test::Hunter::Grizly
       hunt_for Test::Hunter::Argumented
 
       hunt_for Test::Hunter::Zoo
@@ -79,8 +78,8 @@ describe Scorpion::Hunter do
   end
 
   it "spawns the same instance for captured dependency" do
-    first = hunter.fetch_by_traits Test::Hunter::Beast, :tame
-    expect( hunter.fetch_by_traits(Test::Hunter::Beast, :tame) ).to be first
+    first = hunter.fetch Test::Hunter::Lion
+    expect( hunter.fetch(Test::Hunter::Lion) ).to be first
   end
 
   it "injects nested objects" do
@@ -95,10 +94,6 @@ describe Scorpion::Hunter do
 
   it "implicitly spawns Class contracts" do
     expect( hunter.fetch(Test::Hunter::Implicit) ).to be_a Test::Hunter::Implicit
-  end
-
-  it "implicitly spawns Class contracts with empty traits" do
-    expect( hunter.fetch_by_traits(Test::Hunter::Implicit, []) ).to be_a Test::Hunter::Implicit
   end
 
   it "initialize explicit contracts" do


### PR DESCRIPTION
Traits were meant to provide a way of asking for an implementation of a
contract with additional 'conceptual' behavior. After more than a year
in production, traits have never been used. The additional behavior is
always defined by a new contract which is clearer and easier to reason
about.